### PR TITLE
:sparkles: Add test workflow

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -1,0 +1,19 @@
+name: Test addLabel Action
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run addLabel Action
+        uses: ./
+        with:
+          labels: 'hello;there'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          delimiter: ';'

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A fast GitHub Action to add specific labels, seperated by custom delimeter, to a
 |--------------|------------------------------------------------------------|----------|
 | labels       | A list of labels to add, separated by the chosen delimiter.| Yes      |
 | github_token | GitHub token to authenticate.                              | Yes      |
-| delimiter    | Delimiter used to separate labels (default: <code>|</code>).| No       |
+| delimiter    | Delimiter used to separate labels (default: <code>&#124;</code>).| No       |
 
 ## How it works
 


### PR DESCRIPTION
This pull request introduces a new GitHub Action to add specific labels to issues and pull requests, along with a corresponding workflow for testing. It also updates the documentation to clarify the default delimiter for labels.

### GitHub Action and Workflow:

* [`.github/workflows/test-workflow.yml`](diffhunk://#diff-8ac5fe4aa6b2ddd6cab6b427f3fda3fd80949b3f23a2e0402d95a58c470cb0f3R1-R19): Added a new workflow to test the `addLabel` GitHub Action. This workflow triggers on `issues` and `pull_request` events of type `opened`, and it runs the action with specified labels and a custom delimiter.

### Documentation Update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L27-R27): Updated the description of the `delimiter` input to clarify the default delimiter, replacing the pipe character (`|`) with its HTML-encoded equivalent (`&#124;`).