### PR TITLE
:sparkles: Add stuff for v2

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -1,4 +1,4 @@
-name: Test addLabel Action
+name: Test addLabels Action
 
 on:
   issues:
@@ -15,8 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Run addLabel Action
+      - name: Run addLabels Action (multiline)
         uses: ./
         with:
-          labels: ["hello","there"]
+          labels: |
+            - hello
+            - there
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        
+      - name: Run addLabels Action (one line)
+        uses: ./
+        with:
+          labels: 'feature'
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![GitHub pull requests](https://img.shields.io/github/issues-pr/IamPekka058/addLabels)
 ![License: MIT](https://img.shields.io/github/license/IamPekka058/addLabels)
 
-A fast GitHub Action to add specific labels (provided as a JSON array) to a pull request or issue using the GitHub REST API.
+A fast GitHub Action to add specific labels (provided as a YAML list) to a pull request or issue using the GitHub REST API.
 
 ## Usage
 
@@ -12,7 +12,9 @@ A fast GitHub Action to add specific labels (provided as a JSON array) to a pull
 - name: Add labels to PR or Issue
   uses: IamPekka058/addLabels@v1
   with:
-    labels: '["bug", "help wanted"]'
+    labels: |
+      - bug
+      - help wanted
     github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
@@ -20,12 +22,12 @@ A fast GitHub Action to add specific labels (provided as a JSON array) to a pull
 
 | Name         | Description                                                      | Required |
 |--------------|------------------------------------------------------------------|----------|
-| labels       | A JSON array of labels to add, e.g. ["bug", "help wanted"].     | Yes      |
+| labels       | A YAML list of labels to add, e.g. as multiline: - bug - help wanted. | Yes      |
 | github_token | GitHub token to authenticate.                                    | Yes      |
 
 ## How it works
 
-This action detects whether the workflow was triggered by a pull request or an issue and adds the specified labels using the GitHub REST API. The labels input must be a valid JSON array.
+This action detects whether the workflow was triggered by a pull request or an issue and adds the specified labels using the GitHub REST API. The labels input must be a valid YAML list (multiline, e.g. - bug - help wanted).
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,10 @@
 name: 'Add Labels to PR or Issue'
-description: 'A fast GitHub Action to add specific labels to a pull request or issue using the GitHub API.'
+description: 'A fast GitHub Action to add specific labels (provided as a YAML list) to a pull request or issue using the GitHub API.'
 author: 'IamPekka058 <59747867+IamPekka058@users.noreply.github.com>'
 
 inputs:
   labels:
-    description: 'A JSON array of labels to add, e.g. ["bug", "help wanted"].'
+    description: 'A YAML list of labels to add, e.g. [bug, help wanted] or as multiline: - bug\n  - help wanted.'
     required: true
   github_token:
     description: 'GitHub token to authenticate.'
@@ -28,7 +28,7 @@ runs:
           echo "No pull request or issue found in the context."
           exit 1
         fi
-        bash ${{ github.action_path }}/add-labels.sh "${{ inputs.labels }}" "$NUMBER" "|"
+        bash ${{ github.action_path }}/add-labels.sh "${{ inputs.labels }}" "$NUMBER"
 
 branding:
   icon: 'plus-circle'

--- a/add-labels.sh
+++ b/add-labels.sh
@@ -5,7 +5,7 @@ LABELS_RAW="$1"
 NUMBER="$2"
 
 if [[ -z "$LABELS_RAW" || -z "$NUMBER" || -z "$REPO" ]]; then
-  echo "Usage: $0 '[\"label1\", \"label2\"]' <issue_number> <owner/repo>"
+  echo "Usage: $0 '<YAML label list>' <issue_number> <owner/repo>"
   exit 1
 fi
 
@@ -14,13 +14,27 @@ if [[ -z "$GITHUB_TOKEN" ]]; then
   exit 1
 fi
 
-# Only accept LABELS_RAW as a JSON array
+# Reject JSON array, only accept YAML list
 if [[ "$LABELS_RAW" =~ ^\[.*\]$ ]]; then
-  LABELS_JSON="$LABELS_RAW"
-else
-  echo "Labels must be provided as a JSON array, e.g. ['label1', 'label2']."
+  echo "Error: Only a YAML list is accepted, not a JSON array."
   exit 1
 fi
+
+# Convert YAML list to JSON array
+LABELS_JSON="["
+FIRST=1
+while IFS= read -r label; do
+  label_trimmed="$(echo "$label" | sed 's/^- *//' | xargs)"
+  if [[ -n "$label_trimmed" ]]; then
+    if [[ $FIRST -eq 1 ]]; then
+      LABELS_JSON+="\"$label_trimmed\""
+      FIRST=0
+    else
+      LABELS_JSON+=", \"$label_trimmed\""
+    fi
+  fi
+done <<< "$LABELS_RAW"
+LABELS_JSON+="]"
 
 API_URL="https://api.github.com/repos/$REPO/issues/$NUMBER/labels"
 


### PR DESCRIPTION
This pull request updates the `addLabels` GitHub Action to use YAML lists instead of JSON arrays for specifying labels. It includes changes to documentation, workflow configuration, and implementation scripts to support this new input format.

### Documentation and Configuration Updates:
* Updated the `README.md` to reflect the change from JSON arrays to YAML lists for specifying labels, including examples and input descriptions.
* Modified `action.yml` to describe the `labels` input as a YAML list, with examples for both single-line and multiline formats.

### Workflow Changes:
* Updated `.github/workflows/test-workflow.yml` to use YAML lists in the test cases, with examples for both multiline and single-line formats.

### Script Implementation:
* Updated `add-labels.sh` to reject JSON arrays and convert YAML lists into JSON arrays internally for API compatibility. Added error handling and YAML-to-JSON conversion logic.
* Adjusted the usage message in `add-labels.sh` to indicate that only YAML lists are accepted.

These changes ensure consistency across documentation, workflows, and the core implementation while improving the user experience by adopting a more human-readable input format.